### PR TITLE
Bug Fix: Use C locale for lscpu command

### DIFF
--- a/analy.py
+++ b/analy.py
@@ -1,6 +1,6 @@
 import numpy
 import os
-outcpy = out = os.popen('lscpu').read()
+outcpy = out = os.popen('LC_ALL=C lscpu').read()
 idx = out.find('Model name:')
 if idx > 0:
     out = " ".join(out[idx:].split('\n')[0].split()[2:])


### PR DESCRIPTION
The lscpu command is locale-dependent, since the analy.py script does not take this into account, parsing the output may fail.

An example of this follows below:
```bash
$ LC_ALL="fr_FR.UTF-8" lscpu
Architecture :                          x86_64
Mode(s) opératoire(s) des processeurs : 32-bit, 64-bit
Boutisme :                              Little Endian
Tailles des adresses:                   39 bits physical, 48 bits virtual
Processeur(s) :                         4
Liste de processeur(s) en ligne :       0-3
Thread(s) par cœur :                    1
Cœur(s) par socket :                    4
Socket(s) :                             1
Nœud(s) NUMA :                          1
Identifiant constructeur :              GenuineIntel
Famille de processeur :                 6
Modèle :                                158
Nom de modèle :                         Intel(R) Core(TM) i5-7300HQ CPU @ 2.50GHz <- here
-- snip --
```

Fix this by invoking the command with the C locale.