### PR TITLE
Bug Fix: Fix vulnerability report for older kernels

### DIFF
--- a/analy.py
+++ b/analy.py
@@ -9,6 +9,8 @@ end = outcpy.find('Vulnerability Spec store bypass:')
 
 if beg > 0 and end > 0:
     outcpy = " ".join(outcpy[beg:end].split('\n')[0].split()[2:])
+else:
+    outcpy = "Unknown"
 
 print('\nModel name: %s' % (out))
 print('Vulnerability Meltdown: %s\n' % (outcpy))


### PR DESCRIPTION
The analy.py script assumes that it will always run on a kernel that has the fixes for the vulnerabilities (even if disabled),
that exports the vulnerabilities folder in: `/sys/devices/system/cpu/vulnerabilities` (used by lscpu) and that the Linux distribution has a version of lscpu that  supports the above features.

If this set of conditions is not met, the output of 'make testing' displays all the output from lscpu, which is not what is desired.
Fix this by reporting 'Unknown' for old systems that do not have these fixes.

An example of output for old kernels would be (v4.4.38):
```text
Model name: Intel(R) Core(TM) i7-2600 CPU @ 3.40GHz
Vulnerability Meltdown: Unknown

Avg of mode switch takes 248.76 cycles and standard deviation is 57.08
```

Notes:
- Please note that this is the simplest solution to the problem, as it does not inform the user if the system is affected or not.

  - For this, a more sophisticated solution would be necessary, perhaps similar to what Linux [does](https://github.com/torvalds/linux/commit/c456442cd3a59eeb1d60293c26cbe2ff2c4e42cf), checking the vendor, family, etc. of the processor. (I can work on it if you want...)

- Also note that even without informing whether the system is affected or not, the project is still very useful for analyzing time regressions in mode switching between different versions of the Linux kernel.

  - Thinking about regressions, it would be interesting if the output showed the kernel version running, possibly via the output of `uname -r`.